### PR TITLE
Adds client side errors better with 400 and error message for invalid…

### DIFF
--- a/greent/services/ontology.py
+++ b/greent/services/ontology.py
@@ -323,7 +323,8 @@ class GenericOntology(Service):
 
     def lookup(self, identifier):
         """ Given an identifier, find ids in the ontology for which it is an xref. """
-        assert identifier and ':' in identifier, "Must provide a valid identifier."
+        assert identifier and ':' in identifier, "Must provide a valid curie. Curie must have format " \
+                                                 "<PREFIX>:<ID>"
         query_template = """
         PREFIX XREF: <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         PREFIX LABEL: <http://www.w3.org/2000/01/rdf-schema#label>


### PR DESCRIPTION
* Returns a 400 error with an error message for these cases:
   - Curie prefix is not in predefined set of prexies 
   - Curie format doesn't match <PREFIX>:<ID> 
  Returned response for these cases is a json dict with error message about the issue.